### PR TITLE
Use completion handler for UIApplication.openURL on iOS. This fixes "…

### DIFF
--- a/CHANGELIST
+++ b/CHANGELIST
@@ -1,0 +1,4 @@
+0.0.4
+Fixed an issue with opening system settings on iOS. Previously, users reported a terminal warning:
+“BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(:) needs to migrate to the non-deprecated UIApplication.open(:options:completionHandler:). Force returning false (NO).”
+This version updates the implementation to use the modern API and resolves the warning.

--- a/permissions/build.gradle.kts
+++ b/permissions/build.gradle.kts
@@ -70,7 +70,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
-    coordinates("com.lynxal.permissions", "permissions", "0.0.3")
+    coordinates("com.lynxal.permissions", "permissions", "0.0.4")
     pom {
         name.set("KMM Permissions")
         description.set("A Kotlin Multiplatform Mobile (KMM) library for managing permissions in Android and iOS applications, designed with Jetpack Compose in mind and optimized for modern platforms.")

--- a/permissions/src/iosMain/kotlin/com/lynxal/kmmpermissions/PermissionControllerImpl.kt
+++ b/permissions/src/iosMain/kotlin/com/lynxal/kmmpermissions/PermissionControllerImpl.kt
@@ -27,7 +27,7 @@ class PermissionControllerImpl : PermissionsController {
     override suspend fun openAppSettings() {
         NSURL.URLWithString(UIApplicationOpenSettingsURLString)?.also { url ->
             if (UIApplication.sharedApplication.canOpenURL(url)) {
-                UIApplication.sharedApplication.openURL(url)
+                UIApplication.sharedApplication.openURL(url, mapOf<Any?, Any?>()) {}
             } else {
                 throw CannotOpenSettingsException("Could not open the app settings")
             }


### PR DESCRIPTION
…BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO)."